### PR TITLE
Create .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node-modules


### PR DESCRIPTION
Generally, you shouldn't have you node-modules folder in the git repo, because it's unnecessary for end users, and it clutters up your repo. You can use a .gitignore file to hide files and folders in a git repo.